### PR TITLE
Swift Package Manager support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,12 +34,11 @@ xcuserdata/
 timeline.xctimeline
 playground.xcworkspace
 
-# Swift Package Manager
-#
-# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
-# Packages/
-# Package.pins
+## Swift Package Manager
 .build/
+Packages/
+*.xcodeproj
+.swiftpm/
 
 # CocoaPods
 #

--- a/Demo (tvOS)/Base.lproj/Main.storyboard
+++ b/Demo (tvOS)/Base.lproj/Main.storyboard
@@ -57,6 +57,9 @@
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="fjo-G3-uQb">
                                         <rect key="frame" x="0.0" y="0.0" width="1740" height="128"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="300" id="vWO-ef-VMx"/>
+                                        </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JmV-iE-bQu">
                                         <rect key="frame" x="0.0" y="144" width="92" height="46"/>

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,37 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "BoxCast",
+    platforms: [
+        .iOS(.v9),
+        .tvOS(.v9),
+        .macOS(.v10_12),
+    ],
+    products: [
+        .library(
+            name: "BoxCast",
+            targets: ["BoxCast"]),
+    ],
+    targets: [
+        .target(
+            name: "BoxCast",
+            dependencies: [],
+            path: "./Source",
+            exclude: [
+                "Info.plist",
+            ]),
+        .testTarget(
+            name: "BoxCast-Tests",
+            dependencies: ["BoxCast"],
+            path: "./Tests",
+            exclude: [
+                "Info.plist",
+            ],
+            resources: [
+                .copy("Fixtures")
+            ]
+        ),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ $ pod install
 	$(SRCROOT)/Carthage/Build/iOS/BoxCast.framework
 	```
 
+### Swift Package Manager
+SPM is a dependency manager built in to Xcode. Add this package using the url:
+
+```
+https://github.com/boxcast/boxcast-sdk-apple
+```
+
+
 ## Usage
 
 Before you get started make sure to grab the id of the channel you want to get broadcasts from. This can be found on your [BoxCast Dashboard](https://dashboard.boxcast.com/#/channels).


### PR DESCRIPTION
Hi, I'm back to address Issue https://github.com/boxcast/boxcast-sdk-apple/issues/12

I've added support for Swift Package Manager as an installation/integration method (no real source changes, just an additional manifest at `Package.swift`)

The Package.swift manifest doesn't contain a version string so there shouldn't be any extra work when releasing a new version of the library.

Please take a look. Would be useful to me!